### PR TITLE
Move from using github.com/golang-module/carbon to github.com/dromara…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,14 +6,13 @@ toolchain go1.24.3
 
 require (
 	github.com/Rhymond/go-money v1.0.15
-	github.com/golang-module/carbon/v2 v2.6.9
+	github.com/dromara/carbon/v2 v2.6.11
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/text v0.27.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dromara/carbon/v2 v2.6.9 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dromara/carbon/v2 v2.6.9 h1:kx4D7qqLmNkKRLYo/2n1owtu/A1hfPs4WTGYC2tUFFA=
 github.com/dromara/carbon/v2 v2.6.9/go.mod h1:7GXqCUplwN1s1b4whGk2zX4+g4CMCoDIZzmjlyt0vLY=
-github.com/golang-module/carbon/v2 v2.6.9 h1:GtDPA0O5qaszAPs51whhpimtt3FEEeM90gRBuyWR1W4=
-github.com/golang-module/carbon/v2 v2.6.9/go.mod h1:2JsYhwO7UPnUr+1hfsELAP9qjgIWzNuEz89tA1v4sY0=
+github.com/dromara/carbon/v2 v2.6.11 h1:wnAWZ+sbza1uXw3r05hExNSCaBPFaarWfUvYAX86png=
+github.com/dromara/carbon/v2 v2.6.11/go.mod h1:7GXqCUplwN1s1b4whGk2zX4+g4CMCoDIZzmjlyt0vLY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/pkg/functions/datetime.go
+++ b/pkg/functions/datetime.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/golang-module/carbon/v2"
+	"github.com/dromara/carbon/v2"
 	"github.com/kaptinlin/messageformat-go/pkg/errors"
 	"github.com/kaptinlin/messageformat-go/pkg/messagevalue"
 )

--- a/pkg/messagevalue/datetime.go
+++ b/pkg/messagevalue/datetime.go
@@ -3,7 +3,7 @@ package messagevalue
 import (
 	"time"
 
-	"github.com/golang-module/carbon/v2"
+	"github.com/dromara/carbon/v2"
 	"github.com/kaptinlin/messageformat-go/pkg/bidi"
 )
 


### PR DESCRIPTION
The "real" carbon package seems to be at github.com/dromara/carbon, while github.com/golang-module/carbon is a thin wrapper around it that doesn't seem to add any value.

The golang-module one has been archived, and calls some functions in the real package that were already deprecated in 2.6.9 and have been deleted altogether in 2.6.11.

This PR removes the golang-module/carbon wrapper package and moves to using dromara/carbon directly, and updates the dependency to 2.6.11.

All tests pass.